### PR TITLE
Repo signing key security

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Clients are available for bookworm/amd64, Ubuntu builds are in progress.
 ### Add repository 
 
 ```bash 
-sudo curl -fsSL http://packages.eth-pkg.com/keys/ethpkg-archive-keyring.asc -o /usr/share/keyrings/ethpkg-archive-keyring.asc
+# Add repository signing key EC40382FF4A0ED024EC5E5A320C15C00BED4C263
+sudo curl -fsSL https://packages.eth-pkg.com/keys/ethpkg-archive-keyring.asc -o /usr/share/keyrings/ethpkg-archive-keyring.asc
 
 # Add repository to sources.list
 sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/ethpkg-archive-keyring.asc] http://packages.eth-pkg.com bookworm main" | tee -a /etc/apt/sources.list.d/ethpkg.list

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Clients are available for bookworm/amd64, Ubuntu builds are in progress.
 sudo curl -fsSL https://packages.eth-pkg.com/keys/ethpkg-archive-keyring.asc -o /usr/share/keyrings/ethpkg-archive-keyring.asc
 
 # Add repository to sources.list
-sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/ethpkg-archive-keyring.asc] http://packages.eth-pkg.com bookworm main" | tee -a /etc/apt/sources.list.d/ethpkg.list
+sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/ethpkg-archive-keyring.asc] http://packages.eth-pkg.com bookworm main" | sudo tee -a /etc/apt/sources.list.d/ethpkg.list
 
 # Update package lists
 sudo apt-get update


### PR DESCRIPTION
Current docs suggest getting the signing key from a server and importing it directly. The user should have an easy way to verify it before importing, the key fingerprint should be added to docs and ideally other public channels (keyserver, twitter..).
Another important thing is that the suggested curl call is using http, not a secure connection which is necessary when obtaining sensitive data like key. I tried to change it to https and it seems the server is not configured with https at all. This should be fixed on the server so user can enforce tls with something like `curl --tlsv1.3 --proto =https`.  

edit: The pipe in the second command requires also `sudo` also for `tee`. It could be also just `>>` but I think tee is better. The docs could also mention that if user is in root, sudo should be omitted 