### PR TITLE
Docs fixes and updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,11 @@ jobs:
         
         - name: Sbuild setup
           run: |
-            sudo apt-get update
+            sudo apt update
             # Note this is an older version of sbuild, no need to patch it, yet
             sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86
-            sudo apt-get install -y pkg-config libssl-dev uidmap
-            sudo apt-get install -y libfilesys-df-perl libmime-lite-perl
+            sudo apt install -y pkg-config libssl-dev uidmap
+            sudo apt install -y libfilesys-df-perl libmime-lite-perl
             # change this into actually built version and cache it
             wget https://github.com/eth-pkg/sbuild-ubuntu/releases/download/0.85-6-1/sbuild_0.85.6_all.deb
             wget https://github.com/eth-pkg/sbuild-ubuntu/releases/download/0.85-6-1/libsbuild-perl_0.85.6_all.deb
@@ -103,7 +103,7 @@ jobs:
         - name: piuparts
           run: |
            # installing debian-archive-keyring fails on ubuntu LTS, not sure why, but it says it is already installed
-           # sudo apt-get install -y debian-archive-keyring
+           # sudo apt install -y debian-archive-keyring
            cd ${{ steps.env.outputs.tag_name }}
            ${HOME}/.local/bin/pkg-builder piuparts
   

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -51,11 +51,11 @@ jobs:
         
         - name: Sbuild setup
           run: |
-            sudo apt-get update
+            sudo apt update
             # Note this is an older version of sbuild, no need to patch it, yet
             sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86
-            sudo apt-get install -y pkg-config libssl-dev uidmap
-            sudo apt-get install -y libfilesys-df-perl libmime-lite-perl
+            sudo apt install -y pkg-config libssl-dev uidmap
+            sudo apt install -y libfilesys-df-perl libmime-lite-perl
             # change this into actually built version and cache it
             wget https://github.com/eth-pkg/sbuild-ubuntu/releases/download/0.85-6-1/sbuild_0.85.6_all.deb
             wget https://github.com/eth-pkg/sbuild-ubuntu/releases/download/0.85-6-1/libsbuild-perl_0.85.6_all.deb

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This initiative streamlines the process of packaging diverse Ethereum nodes for Debian-based systems. It offers a systematic approach to generate Debian packages for various Ethereum clients.
 
+The project is still under active development, check out the [roadmap](/Roadmap.md) for upcoming features. 
 
 ## Installing clients 
 
@@ -16,8 +17,10 @@ sudo curl -fsSL http://packages.eth-pkg.com/keys/ethpkg-archive-keyring.asc -o /
 sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/ethpkg-archive-keyring.asc] http://packages.eth-pkg.com bookworm main" | tee -a /etc/apt/sources.list.d/ethpkg.list
 
 # Update package lists
-sudo apt-get update
+sudo apt update
 ```
+
+With the repository added, client releases are now available to be simply istalled using apt. Some clients might need additional runtime dependencies. 
 
 ### besu 
 ```bash
@@ -191,6 +194,8 @@ pkg-builder verify
 
 ## Verifying distributed packages 
 
+For more details and options of verification refer to `verify.md` in corresponding client release.  
+
 ```bash
 mkdir /tmp/tempdir | cd -
 sudo apt-get download <package_name>
@@ -209,6 +214,6 @@ cat releases/bookworm/amd64/eth-node-teku/24.4.0-1/pkg-builder-verify.toml # che
 
 ## How It Works
 
-This process leverages `debcrafter` and `pkg-builder` to establish reproducible environments. Debcrafter aids in creating reproducible Debian directories based on detailed specification files ending with `.sss` and `.sps`. Meanwhile, pkg-builder utilizes debcrafter, and extends it to setup minimal environments to build and adheres to Debian's best practices, including `sbuild`, `piuparts`, `lintian`, and `autopkgtest`, to build the packages and test them thoroughly, ensuring they are not merely packages but functional ones.
+This process leverages [`debcrafter`](https://github.com/Kixunil/debcrafter) and [`pkg-builder`](https://github.com/eth-pkg/pkg-builder/) to establish reproducible environments. Debcrafter aids in creating reproducible Debian directories based on detailed specification files ending with `.sss` and `.sps`. Meanwhile, pkg-builder utilizes debcrafter, and extends it to setup minimal environments to build and adheres to Debian's best practices, including `sbuild`, `piuparts`, `lintian`, and `autopkgtest`, to build the packages and test them thoroughly, ensuring they are not merely packages but functional ones.
 
 Currently, a significant obstacle in Debian packaging is the requirement for a separate git repository per package, which might hinder the support for numerous applications. Despite Debian packaging already facilitating reproducible builds, this aspect is still in its infancy. This project aims to adhere to distribution best practices to the fullest extent possible, only deviating when necessary or when certain support structures are not yet in place.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ geth
 ### lodestar
 ```bash
 curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - &&\
-sudo apt-get install -y nodejs
+sudo apt install -y nodejs
 sudo apt install eth-node-lodestar
 ```
 
@@ -89,8 +89,8 @@ lodestar
 wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
-sudo apt-get update 
-sudo apt-get install -y aspnetcore-runtime-7.0
+sudo apt update 
+sudo apt install -y aspnetcore-runtime-7.0
 
 sudo apt install eth-node-nethermind
 ```
@@ -198,7 +198,7 @@ For more details and options of verification refer to `verify.md` in correspondi
 
 ```bash
 mkdir /tmp/tempdir | cd -
-sudo apt-get download <package_name>
+sudo apt download <package_name>
 sha1sum  <package_name>*.deb
 ```
 
@@ -206,7 +206,7 @@ Check the appropriate folder `pkg-builder-verify.toml` for hash.
 
 So for example if you want to verify teku 
 ```bash
-sudo apt-get download eth-node-teku
+sudo apt download eth-node-teku
 # Get:1 http://packages.eth-pkg.com bookworm/main amd64 eth-node-teku amd64 24.4.0-1 [176 MB]
 sha1sum eth-node-teku_24.4.0-1_amd64.deb # 541013cb73f767d94e19169c5685d01f8d145803
 cat releases/bookworm/amd64/eth-node-teku/24.4.0-1/pkg-builder-verify.toml # check if the hash is indeed the same

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -50,7 +50,7 @@ sudo chmod a+r /etc/apt/keyrings/ethpkg.asc
 sudo echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ethpkg.asc] $REPO_URL bookworm testing" | tee -a /etc/apt/sources.list/ethpkg.list
 
 # Update package lists
-sudo apt-get update
+sudo apt update
 
 
 # Install besu
@@ -77,7 +77,7 @@ sudo apt install eth-node-erigon
 
 # Install lodestar
 curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - &&\
-sudo apt-get install -y nodejs
+sudo apt install -y nodejs
 sudo apt install eth-node-lodestar
 
 
@@ -87,8 +87,8 @@ sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
 
   # Install the runtime
-sudo apt-get update 
-sudo apt-get install -y aspnetcore-runtime-7.0
+sudo apt update 
+sudo apt install -y aspnetcore-runtime-7.0
 
 sudo apt install eth-node-nethermind
 
@@ -179,7 +179,7 @@ sudo chmod a+r /etc/apt/keyrings/ethpkg.asc
 sudo echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ethpkg.asc] $REPO_URL bookworm testing" | tee -a /etc/apt/sources.list/ethpkg.list
 
 # Update package lists
-sudo apt-get update
+sudo apt update
 
 # Install dependencies (node.js, dotnet, java) to satisfy dependencies
 # If you know which client pairs you want, you can ignore the dependencies if not needed
@@ -199,7 +199,7 @@ java -version
 
 # Install node.js
 curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - &&\
-sudo apt-get install -y nodejs
+sudo apt install -y nodejs
 
 # Install dotnet
 wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -207,8 +207,8 @@ sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
 
   # Install the runtime
-sudo apt-get update 
-sudo apt-get install -y aspnetcore-runtime-7.0
+sudo apt update 
+sudo apt install -y aspnetcore-runtime-7.0
 
 # Install any of the following
 
@@ -277,7 +277,7 @@ sudo chmod a+r /etc/apt/keyrings/ethpkg.asc
 sudo echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ethpkg.asc] $REPO_URL bookworm testing" | tee -a /etc/apt/sources.list/ethpkg.list
 
 # Update package lists
-sudo apt-get update
+sudo apt update
 
 # Install any of the following
 

--- a/releases/bookworm/amd64/eth-node-besu/24.3.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-besu/24.3.3-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-besu/24.3.3-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-besu/24.3.3-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-besu/24.3.3-1
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-besu/24.3.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-besu/24.3.3-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-besu/24.3.3-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-erigon/2.59.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-erigon/2.59.3-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-erigon/2.59.3-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-erigon/2.59.3-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-erigon/2.59.3-1
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-erigon/2.59.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-erigon/2.59.3-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-erigon/2.59.3-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-geth/1.14.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-geth/1.14.0-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-geth/1.14.0-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-geth/1.14.0-1 https://github.com/eth-pkg/eth-nodes.git
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-geth/1.14.0-1
 ```
@@ -43,28 +43,23 @@ cd releases/bookworm/amd64/eth-node-geth/1.14.0-1
 sudo apt-get update
 sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
-sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
+sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap libfilesys-df-perl libmime-lite-perl
  # change this into the built version and cache it
 sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
-If you are on *Ubuntu* clone 
+Clone the sbuild fork repository:
 
 ```bash
 git clone https://github.com/eth-pkg/sbuild-ubuntu.git
 ```
 
-If you are on *Debian clone 
-
-```bash 
-git clone https://github.com/eth-pkg/sbuild-ubuntu.git
-```
 
 Install forked sbuild
 ```bash
 cd sbuild 
 # Build the package
-dpkg-build package -us -uc  
+dpkg-buildpackage -us -uc  
 # Install the newly built package 
 cd .. && sudo dpkg -i sbuild_0.85.6_all.deb libsbuild-perl_0.85.6_all.deb            
 ```

--- a/releases/bookworm/amd64/eth-node-geth/1.14.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-geth/1.14.0-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-geth/1.14.0-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap libfilesys-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 Clone the sbuild fork repository:

--- a/releases/bookworm/amd64/eth-node-geth/1.14.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-geth/1.14.0-1/Verify.md
@@ -75,7 +75,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1 
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-lighthouse/5.1.3-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-lodestar/1.18.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-lodestar/1.18.0-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-lodestar/1.18.0-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-lodestar/1.18.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-lodestar/1.18.0-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-lodestar/1.18.0-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-lodestar/1.18.0-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-lodestar/1.18.0-1
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-nethermind/1.26.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-nethermind/1.26.0-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-nethermind/1.26.0-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-nethermind/1.26.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-nethermind/1.26.0-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-nethermind/1.26.0-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-nethermind/1.26.0-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-nethermind/1.26.0-1 
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1 
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1/src/.pc/001-makefile.patch/vendor/nimbus-build-system/makefiles/targets.mk
+++ b/releases/bookworm/amd64/eth-node-nimbus-eth2/24.3.0-1/src/.pc/001-makefile.patch/vendor/nimbus-build-system/makefiles/targets.mk
@@ -165,8 +165,8 @@ mrproper: clean
 
 # for when you want to use SSH keys with GitHub
 github-ssh:
-	git config url."git@github.com:".insteadOf "https://github.com/"
-	git submodule foreach --recursive 'git config url."git@github.com:".insteadOf "https://github.com/"'
+	git config url."https://github.com/".insteadOf "https://github.com/"
+	git submodule foreach --recursive 'git config url."https://github.com/".insteadOf "https://github.com/"'
 
 # runs `git status` in all Git repos
 status: | $(REPOS)

--- a/releases/bookworm/amd64/eth-node-prysm/5.0.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-prysm/5.0.3-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-prysm/5.0.3-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-prysm/5.0.3-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-prysm/5.0.3-1 
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-prysm/5.0.3-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-prysm/5.0.3-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-prysm/5.0.3-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/releases/bookworm/amd64/eth-node-teku/24.4.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-teku/24.4.0-1/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch releases/bookworm/amd64/eth-node-teku/24.4.0-1 git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch releases/bookworm/amd64/eth-node-teku/24.4.0-1 https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd releases/bookworm/amd64/eth-node-teku/24.4.0-1 
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/releases/bookworm/amd64/eth-node-teku/24.4.0-1/Verify.md
+++ b/releases/bookworm/amd64/eth-node-teku/24.4.0-1/Verify.md
@@ -40,12 +40,12 @@ cd releases/bookworm/amd64/eth-node-teku/24.4.0-1
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 

--- a/templates/Verify.md
+++ b/templates/Verify.md
@@ -21,7 +21,7 @@ Check out the main repo and navigate to the release you want to verify.
 From git 
 
 ```bash
-git clone --branch <RELATIVE_PATH> git@github.com:eth-pkg/eth-nodes.git 
+git clone --branch <RELATIVE_PATH> https://github.com/eth-pkg/eth-nodes.git 
 cd eth-nodes
 cd <RELATIVE_PATH> 
 ```
@@ -80,7 +80,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # rust if you don
 ```
 
 ```bash 
-git clone --branch v0.2.2 git@github.com:eth-pkg/pkg-builder.git
+git clone --branch v0.2.2 https://github.com/eth-pkg/pkg-builder.git
 cd pkg-builder 
 cargo build --release && cargo install --path .
 pkg-builder --version # should be available in PATH

--- a/templates/Verify.md
+++ b/templates/Verify.md
@@ -40,12 +40,12 @@ cd <RELATIVE_PATH>
 
 #### Install sbuild if you don't have it yet
 ```bash 
-sudo apt-get update
-sudo apt-get -y remove sbuild # remove old sbuild if you had installed it
+sudo apt update
+sudo apt -y remove sbuild # remove old sbuild if you had installed it
 # Note this is an older version of sbuild; there is no need to patch it yet
 sudo apt install -y debhelper schroot ubuntu-dev-tools piuparts autopkgtest vmdb2 qemu-system-x86 pkg-config libssl-dev uidmap lifeless-df-perl libmime-lite-perl
  # change this into the built version and cache it
-sudo apt-get install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
+sudo apt install dh-python dh-sequence-python3 libyaml-tiny-perl python3-all            
 ```
 
 If you are on *Ubuntu* clone 


### PR DESCRIPTION
Added links and clarification to readme, fixed issues I stumbled upon in verification process. I went through verify.md docs for geth and had few issues like wrong package name, ssh git clonining instead of https. I might have missed something tho, I only tried a single way. 

It's cool that verify.md is generated for each client release but I think it could be just a single doc in the root of the repo linked in the readme. I didn't do this change because I am not completely convinced but I think it could be a single doc with examples. Let me know what do you think. 

The second commit changes apt-get to apt because it's more modern and I think should be preferred. Docs interchange them I would rather just keep it all as apt. But if it breaks something, feel free to revert! 